### PR TITLE
+ Fixed type 'ChagilyEpay' -->  'ChargilyEpay'

### DIFF
--- a/Chargily.Epay.CSharp.AspNetCore.MinimalAPIExample/Program.cs
+++ b/Chargily.Epay.CSharp.AspNetCore.MinimalAPIExample/Program.cs
@@ -1,4 +1,4 @@
-using chargily.epay.csharp;
+using Chargily.Epay;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/Chargily.Epay.CSharp/Chargily.Epay.CSharp.csproj
+++ b/Chargily.Epay.CSharp/Chargily.Epay.CSharp.csproj
@@ -7,7 +7,7 @@
 	  <PackageReadmeFile>readme.md</PackageReadmeFile>
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <OutputType>Library</OutputType>
-	  <Version>1.0.0</Version>
+	  <Version>1.1.0</Version>
 	  <StartupObject />
 	  <Authors>Chargily</Authors>
 	  <Description>C# .NET Library to use Chargily Epay</Description>

--- a/Chargily.Epay.CSharp/ChargilyApIConfig.cs
+++ b/Chargily.Epay.CSharp/ChargilyApIConfig.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class ChargilyApIConfig
     {

--- a/Chargily.Epay.CSharp/ChargilyEpay.cs
+++ b/Chargily.Epay.CSharp/ChargilyEpay.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using chargily.epay.csharp.Validations;
+using Chargily.Epay.Validations;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
-    public static class ChagilyEpay
+    public static class ChargilyEpay
     {
         private static ChargilyEpayClient _client = null;
         private static IServiceProvider _provider;

--- a/Chargily.Epay.CSharp/ChargilyEpayClient.cs
+++ b/Chargily.Epay.CSharp/ChargilyEpayClient.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class ChargilyEpayClient : IChargilyEpayClient<EpayPaymentResponse, EpayPaymentRequest>
     {

--- a/Chargily.Epay.CSharp/ChargilyEpayService.cs
+++ b/Chargily.Epay.CSharp/ChargilyEpayService.cs
@@ -3,11 +3,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Refit;
 using FluentValidation;
 using System.Net.Http;
-using chargily.epay.csharp.Validations;
+using Chargily.Epay.Validations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public static partial class ChargilyEpayService
     {

--- a/Chargily.Epay.CSharp/EpayPaymentRequest.cs
+++ b/Chargily.Epay.CSharp/EpayPaymentRequest.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class EpayPaymentRequest
     {

--- a/Chargily.Epay.CSharp/EpayPaymentResponse.cs
+++ b/Chargily.Epay.CSharp/EpayPaymentResponse.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class EpayPaymentResponse
     {

--- a/Chargily.Epay.CSharp/IChargilyEpayAPI.cs
+++ b/Chargily.Epay.CSharp/IChargilyEpayAPI.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Refit;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public interface IChargilyEpayAPI
     {

--- a/Chargily.Epay.CSharp/IChargilyEpayClient.cs
+++ b/Chargily.Epay.CSharp/IChargilyEpayClient.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public interface IChargilyEpayClient<TResponse, TRequest>
     {

--- a/Chargily.Epay.CSharp/IWebHookValidator.cs
+++ b/Chargily.Epay.CSharp/IWebHookValidator.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public interface IWebHookValidator
     {

--- a/Chargily.Epay.CSharp/PaymentMethod.cs
+++ b/Chargily.Epay.CSharp/PaymentMethod.cs
@@ -1,4 +1,4 @@
-﻿namespace chargily.epay.csharp
+﻿namespace Chargily.Epay
 {
     public enum PaymentMethod
     {

--- a/Chargily.Epay.CSharp/PaymentRequest.cs
+++ b/Chargily.Epay.CSharp/PaymentRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class PaymentRequest
     {

--- a/Chargily.Epay.CSharp/Validations/PaymentRequestValidator.cs
+++ b/Chargily.Epay.CSharp/Validations/PaymentRequestValidator.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using FluentValidation;
 
-namespace chargily.epay.csharp.Validations
+namespace Chargily.Epay.Validations
 {
     public class PaymentRequestValidator : AbstractValidator<EpayPaymentRequest>
     {

--- a/Chargily.Epay.CSharp/WebHookValidator.cs
+++ b/Chargily.Epay.CSharp/WebHookValidator.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class WebHookValidator : IWebHookValidator
     {

--- a/Chargily.Epay.CSharp/WebHookValidatorMiddleware.cs
+++ b/Chargily.Epay.CSharp/WebHookValidatorMiddleware.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     public class WebHookValidatorMiddleware : IMiddleware
     {

--- a/Chargily.Epay.CSharp/WebHookValidatorService.cs
+++ b/Chargily.Epay.CSharp/WebHookValidatorService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
-namespace chargily.epay.csharp
+namespace Chargily.Epay
 {
     /// <summary>
     /// Chargily Epay Services 

--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -1,10 +1,10 @@
 ﻿using System.Text.Json;
-using chargily.epay.csharp;
+using Chargily.Epay;
 
 Console.Write($"Provide Chargily API_KEY : ");
 var apiKey = Console.ReadLine();
 
-var client = ChagilyEpay.CreateClient(apiKey);
+var client = ChargilyEpay.CreateClient(apiKey);
 
 var payment = new EpayPaymentRequest()
 {

--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ Install-Package chargily.epay.csharp
 1. Get your API Key/Secret from [ePay by Chargily](https://epay.chargily.com.dz) dashboard for free
 
 # How to use
+### Installation & Project Creation Video Guide
+*Soon*
+
 ### __Usage with any generic C# Project:__
 this package provide `ChargilyEpayClient` client, to create payment request use: 
 ```csharp
-using chargily.epay.csharp;
+using Chargily.Epay;
 
-var client = ChagilyEpay.CreateClient("[API_KEY]");
+var client = ChargilyEpay.CreateClient("[API_KEY]");
 
 var payment = new EpayPaymentRequest()
 {
@@ -72,6 +75,14 @@ var response = await client.CreatePayment(payment);
 ```
 
 # Usage with ASP.NET Core
+
+###  Video Guide how to use with Minimal API
+*Soon*
+
+###  Video Guide how to use with ASP.NET Core WebAPI
+*Soon*
+
+
 ## this applies to: 
 - ASP.NET Core WebAPI
 - ASP.NET Core Minimal WebAPI 
@@ -79,7 +90,7 @@ var response = await client.CreatePayment(payment);
 - Blazor WASM 
 - ASP.NET Core MVC
 ```csharp
-using chargily.epay.csharp;
+using Chargily.Epay;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -128,7 +139,7 @@ app.Run();
 ```
 ### WebHook Validation:
 ```csharp
-using chargily.epay.csharp;
+using Chargily.Epay;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -182,7 +193,7 @@ builder.Services.AddChargilyEpayGateway();
 This package provide `WebHookValidatorMiddleware` ASP.NET Core Middleware, when registered every `POST` request that have a `Signature` Http Header will be validated automatically. 
 How to register the Middleware:
 ```csharp
-using chargily.epay.csharp;
+using Chargily.Epay;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -205,7 +216,7 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using chargily.epay.csharp;
+using Chargily.Epay;
 
 namespace MyApp
 {


### PR DESCRIPTION
+ Renamed namespace from 'chargily.epay.csharp' --> 'Chargily.Epay' to be more aligned with the .NET ecosystem convention of using Pascal case