### PR TITLE
made setters on EpaymentResponse properties internal

### DIFF
--- a/Chargily.Epay.CSharp/EpayPaymentResponse.cs
+++ b/Chargily.Epay.CSharp/EpayPaymentResponse.cs
@@ -10,12 +10,12 @@ namespace Chargily.Epay.CSharp
 {
     public class EpayPaymentResponse
     {
-        public HttpStatusCode HttpStatusCode { get; set; }
-        public JsonDocument ResponseMessage { get; set; }
-        public bool IsSuccessful { get; set; } = false;
-        public bool IsRequestValid { get; set; } = false;
-        public JsonDocument Body { get; set; }
-        public DateTime CreatedOn { get; set; } = DateTime.Now;
+        public HttpStatusCode HttpStatusCode { get; internal set; }
+        public JsonDocument ResponseMessage { get; internal set; }
+        public bool IsSuccessful { get; internal set; } = false;
+        public bool IsRequestValid { get; internal set; } = false;
+        public JsonDocument Body { get; internal set; }
+        public DateTime CreatedOn { get; internal set; } = DateTime.Now;
 
         public async Task CreatePaymentResponse(HttpResponseMessage httpResponse)
         {


### PR DESCRIPTION
Hello, 
Since you are exposing the `EpayPaymentResponse` as a return type for the client, I think at least the property setters on the implementation should be internal.

A better approach would be to make the implementation internal and hide it behind a public interface `IEpayPaymentResponse`, and only expose the properties the getters.